### PR TITLE
fix(smithy): Join paths using forward slashes only

### DIFF
--- a/packages/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/lib/src/http/http_operation.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:built_value/serializer.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 import 'package:retry/retry.dart';
 import 'package:smithy/smithy.dart';
 import 'package:smithy_ast/smithy_ast.dart';

--- a/packages/smithy/lib/src/http/http_operation.dart
+++ b/packages/smithy/lib/src/http/http_operation.dart
@@ -147,7 +147,7 @@ abstract class HttpOperation<InputPayload, Input, OutputPayload, Output>
     if (basePath.startsWith('/')) {
       basePath = basePath.substring(1);
     }
-    path = p.join(basePath, path);
+    path = '$basePath/$path';
     if (needsTrailingSlash && !path.endsWith('/')) {
       path += '/';
     }


### PR DESCRIPTION
Previously, I used `path.join` for URI paths but this is incorrect, since it will use platform-specific behavior to join paths, causing `path.join('a', 'b')` to become `a\b` on Windows, which is not what we want.