### PR TITLE
fix(smithy): Proper enum support

### DIFF
--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/foo_enum.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/foo_enum.dart
@@ -47,6 +47,5 @@ extension FooEnumHelpers on List<FooEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [FooEnum] whose value matches [value].
-  FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum._sdkUnknown(value));
+  FooEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/foo_enum.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/foo_enum.dart
@@ -8,7 +8,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   const FooEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const FooEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const FooEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const bar = FooEnum._(0, 'BAR', 'Bar');
 
@@ -32,7 +32,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   static const List<_i1.SmithySerializer<FooEnum>> serializers = [
     _i1.SmithyEnumSerializer('FooEnum',
         values: values,
-        sdkUnknown: FooEnum.sdkUnknown,
+        sdkUnknown: FooEnum._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_0')
         ])
@@ -48,5 +48,5 @@ extension FooEnumHelpers on List<FooEnum> {
 
   /// Returns the value of [FooEnum] whose value matches [value].
   FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum.sdkUnknown(value));
+      orElse: () => FooEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_0')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_0/lib/src/json_rpc_10/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_0')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/foo_enum.dart
@@ -47,6 +47,5 @@ extension FooEnumHelpers on List<FooEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [FooEnum] whose value matches [value].
-  FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum._sdkUnknown(value));
+  FooEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/foo_enum.dart
@@ -8,7 +8,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   const FooEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const FooEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const FooEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const bar = FooEnum._(0, 'BAR', 'Bar');
 
@@ -32,7 +32,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   static const List<_i1.SmithySerializer<FooEnum>> serializers = [
     _i1.SmithyEnumSerializer('FooEnum',
         values: values,
-        sdkUnknown: FooEnum.sdkUnknown,
+        sdkUnknown: FooEnum._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -48,5 +48,5 @@ extension FooEnumHelpers on List<FooEnum> {
 
   /// Returns the value of [FooEnum] whose value matches [value].
   FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum.sdkUnknown(value));
+      orElse: () => FooEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/json_protocol/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/details_attributes.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/details_attributes.dart
@@ -8,7 +8,7 @@ class DetailsAttributes extends _i1.SmithyEnum<DetailsAttributes> {
   const DetailsAttributes._(int index, String name, String value)
       : super(index, name, value);
 
-  const DetailsAttributes.sdkUnknown(String value) : super.sdkUnknown(value);
+  const DetailsAttributes._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const algorithm = DetailsAttributes._(0, 'ALGORITHM', 'Algorithm');
 
@@ -24,7 +24,7 @@ class DetailsAttributes extends _i1.SmithyEnum<DetailsAttributes> {
   static const List<_i1.SmithySerializer<DetailsAttributes>> serializers = [
     _i1.SmithyEnumSerializer('DetailsAttributes',
         values: values,
-        sdkUnknown: DetailsAttributes.sdkUnknown,
+        sdkUnknown: DetailsAttributes._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -41,5 +41,5 @@ extension DetailsAttributesHelpers on List<DetailsAttributes> {
   /// Returns the value of [DetailsAttributes] whose value matches [value].
   DetailsAttributes byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => DetailsAttributes.sdkUnknown(value));
+          orElse: () => DetailsAttributes._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/details_attributes.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/details_attributes.dart
@@ -40,6 +40,5 @@ extension DetailsAttributesHelpers on List<DetailsAttributes> {
 
   /// Returns the value of [DetailsAttributes] whose value matches [value].
   DetailsAttributes byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => DetailsAttributes._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/retry_mode.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/awsJson1_1/lib/src/machine_learning/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/operation_generator/lib/src/test/model/retry_mode.dart
+++ b/packages/goldens/lib/operation_generator/lib/src/test/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/operation_generator/lib/src/test/model/retry_mode.dart
+++ b/packages/goldens/lib/operation_generator/lib/src/test/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/operation_generator/lib/src/test/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/operation_generator/lib/src/test/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/operation_generator/lib/src/test/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/operation_generator/lib/src/test/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'awsJson1_1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/api_key_source_type.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/api_key_source_type.dart
@@ -8,7 +8,7 @@ class ApiKeySourceType extends _i1.SmithyEnum<ApiKeySourceType> {
   const ApiKeySourceType._(int index, String name, String value)
       : super(index, name, value);
 
-  const ApiKeySourceType.sdkUnknown(String value) : super.sdkUnknown(value);
+  const ApiKeySourceType._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const authorizer = ApiKeySourceType._(0, 'AUTHORIZER', 'AUTHORIZER');
 
@@ -23,7 +23,7 @@ class ApiKeySourceType extends _i1.SmithyEnum<ApiKeySourceType> {
   static const List<_i1.SmithySerializer<ApiKeySourceType>> serializers = [
     _i1.SmithyEnumSerializer('ApiKeySourceType',
         values: values,
-        sdkUnknown: ApiKeySourceType.sdkUnknown,
+        sdkUnknown: ApiKeySourceType._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -40,5 +40,5 @@ extension ApiKeySourceTypeHelpers on List<ApiKeySourceType> {
   /// Returns the value of [ApiKeySourceType] whose value matches [value].
   ApiKeySourceType byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => ApiKeySourceType.sdkUnknown(value));
+          orElse: () => ApiKeySourceType._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/api_key_source_type.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/api_key_source_type.dart
@@ -39,6 +39,5 @@ extension ApiKeySourceTypeHelpers on List<ApiKeySourceType> {
 
   /// Returns the value of [ApiKeySourceType] whose value matches [value].
   ApiKeySourceType byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => ApiKeySourceType._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_type.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_type.dart
@@ -41,6 +41,5 @@ extension EndpointTypeHelpers on List<EndpointType> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [EndpointType] whose value matches [value].
-  EndpointType byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EndpointType._sdkUnknown(value));
+  EndpointType byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_type.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/endpoint_type.dart
@@ -8,7 +8,7 @@ class EndpointType extends _i1.SmithyEnum<EndpointType> {
   const EndpointType._(int index, String name, String value)
       : super(index, name, value);
 
-  const EndpointType.sdkUnknown(String value) : super.sdkUnknown(value);
+  const EndpointType._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const edge = EndpointType._(0, 'EDGE', 'EDGE');
 
@@ -26,7 +26,7 @@ class EndpointType extends _i1.SmithyEnum<EndpointType> {
   static const List<_i1.SmithySerializer<EndpointType>> serializers = [
     _i1.SmithyEnumSerializer('EndpointType',
         values: values,
-        sdkUnknown: EndpointType.sdkUnknown,
+        sdkUnknown: EndpointType._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -42,5 +42,5 @@ extension EndpointTypeHelpers on List<EndpointType> {
 
   /// Returns the value of [EndpointType] whose value matches [value].
   EndpointType byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EndpointType.sdkUnknown(value));
+      orElse: () => EndpointType._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/api_gateway/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/api_gateway/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/glacier/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/glacier/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/glacier/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/glacier/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/glacier/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/glacier/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/glacier/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/glacier/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/foo_enum.dart
@@ -47,6 +47,5 @@ extension FooEnumHelpers on List<FooEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [FooEnum] whose value matches [value].
-  FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum._sdkUnknown(value));
+  FooEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/foo_enum.dart
@@ -8,7 +8,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   const FooEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const FooEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const FooEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const bar = FooEnum._(0, 'BAR', 'Bar');
 
@@ -32,7 +32,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   static const List<_i1.SmithySerializer<FooEnum>> serializers = [
     _i1.SmithyEnumSerializer('FooEnum',
         values: values,
-        sdkUnknown: FooEnum.sdkUnknown,
+        sdkUnknown: FooEnum._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -48,5 +48,5 @@ extension FooEnumHelpers on List<FooEnum> {
 
   /// Returns the value of [FooEnum] whose value matches [value].
   FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum.sdkUnknown(value));
+      orElse: () => FooEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/string_enum.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/string_enum.dart
@@ -8,7 +8,7 @@ class StringEnum extends _i1.SmithyEnum<StringEnum> {
   const StringEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const StringEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const StringEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const v = StringEnum._(0, 'V', 'enumvalue');
 
@@ -18,7 +18,7 @@ class StringEnum extends _i1.SmithyEnum<StringEnum> {
   static const List<_i1.SmithySerializer<StringEnum>> serializers = [
     _i1.SmithyEnumSerializer('StringEnum',
         values: values,
-        sdkUnknown: StringEnum.sdkUnknown,
+        sdkUnknown: StringEnum._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -34,5 +34,5 @@ extension StringEnumHelpers on List<StringEnum> {
 
   /// Returns the value of [StringEnum] whose value matches [value].
   StringEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => StringEnum.sdkUnknown(value));
+      orElse: () => StringEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/string_enum.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_protocol/model/string_enum.dart
@@ -33,6 +33,5 @@ extension StringEnumHelpers on List<StringEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [StringEnum] whose value matches [value].
-  StringEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => StringEnum._sdkUnknown(value));
+  StringEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/enum_string.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/enum_string.dart
@@ -8,7 +8,7 @@ class EnumString extends _i1.SmithyEnum<EnumString> {
   const EnumString._(int index, String name, String value)
       : super(index, name, value);
 
-  const EnumString.sdkUnknown(String value) : super.sdkUnknown(value);
+  const EnumString._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const abc = EnumString._(0, 'ABC', 'abc');
 
@@ -20,7 +20,7 @@ class EnumString extends _i1.SmithyEnum<EnumString> {
   static const List<_i1.SmithySerializer<EnumString>> serializers = [
     _i1.SmithyEnumSerializer('EnumString',
         values: values,
-        sdkUnknown: EnumString.sdkUnknown,
+        sdkUnknown: EnumString._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -36,5 +36,5 @@ extension EnumStringHelpers on List<EnumString> {
 
   /// Returns the value of [EnumString] whose value matches [value].
   EnumString byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EnumString.sdkUnknown(value));
+      orElse: () => EnumString._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/enum_string.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/enum_string.dart
@@ -35,6 +35,5 @@ extension EnumStringHelpers on List<EnumString> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [EnumString] whose value matches [value].
-  EnumString byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EnumString._sdkUnknown(value));
+  EnumString byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/recursive_enum_string.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/recursive_enum_string.dart
@@ -8,7 +8,7 @@ class RecursiveEnumString extends _i1.SmithyEnum<RecursiveEnumString> {
   const RecursiveEnumString._(int index, String name, String value)
       : super(index, name, value);
 
-  const RecursiveEnumString.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RecursiveEnumString._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const abc = RecursiveEnumString._(0, 'ABC', 'abc');
 
@@ -23,7 +23,7 @@ class RecursiveEnumString extends _i1.SmithyEnum<RecursiveEnumString> {
   static const List<_i1.SmithySerializer<RecursiveEnumString>> serializers = [
     _i1.SmithyEnumSerializer('RecursiveEnumString',
         values: values,
-        sdkUnknown: RecursiveEnumString.sdkUnknown,
+        sdkUnknown: RecursiveEnumString._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -40,5 +40,5 @@ extension RecursiveEnumStringHelpers on List<RecursiveEnumString> {
   /// Returns the value of [RecursiveEnumString] whose value matches [value].
   RecursiveEnumString byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => RecursiveEnumString.sdkUnknown(value));
+          orElse: () => RecursiveEnumString._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/recursive_enum_string.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/recursive_enum_string.dart
@@ -39,6 +39,5 @@ extension RecursiveEnumStringHelpers on List<RecursiveEnumString> {
 
   /// Returns the value of [RecursiveEnumString] whose value matches [value].
   RecursiveEnumString byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => RecursiveEnumString._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restJson1/lib/src/rest_json_validation_protocol/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restJson1')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/foo_enum.dart
@@ -47,6 +47,5 @@ extension FooEnumHelpers on List<FooEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [FooEnum] whose value matches [value].
-  FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum._sdkUnknown(value));
+  FooEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/foo_enum.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/foo_enum.dart
@@ -8,7 +8,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   const FooEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const FooEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const FooEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const bar = FooEnum._(0, 'BAR', 'Bar');
 
@@ -32,7 +32,7 @@ class FooEnum extends _i1.SmithyEnum<FooEnum> {
   static const List<_i1.SmithySerializer<FooEnum>> serializers = [
     _i1.SmithyEnumSerializer('FooEnum',
         values: values,
-        sdkUnknown: FooEnum.sdkUnknown,
+        sdkUnknown: FooEnum._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -48,5 +48,5 @@ extension FooEnumHelpers on List<FooEnum> {
 
   /// Returns the value of [FooEnum] whose value matches [value].
   FooEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => FooEnum.sdkUnknown(value));
+      orElse: () => FooEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/retry_mode.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXml/lib/src/rest_xml_protocol/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/bucket_location_constraint.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/bucket_location_constraint.dart
@@ -9,7 +9,7 @@ class BucketLocationConstraint
   const BucketLocationConstraint._(int index, String name, String value)
       : super(index, name, value);
 
-  const BucketLocationConstraint.sdkUnknown(String value)
+  const BucketLocationConstraint._sdkUnknown(String value)
       : super.sdkUnknown(value);
 
   static const usWest2 =
@@ -24,7 +24,7 @@ class BucketLocationConstraint
       serializers = [
     _i1.SmithyEnumSerializer('BucketLocationConstraint',
         values: values,
-        sdkUnknown: BucketLocationConstraint.sdkUnknown,
+        sdkUnknown: BucketLocationConstraint._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -41,5 +41,5 @@ extension BucketLocationConstraintHelpers on List<BucketLocationConstraint> {
   /// Returns the value of [BucketLocationConstraint] whose value matches [value].
   BucketLocationConstraint byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => BucketLocationConstraint.sdkUnknown(value));
+          orElse: () => BucketLocationConstraint._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/bucket_location_constraint.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/bucket_location_constraint.dart
@@ -40,6 +40,5 @@ extension BucketLocationConstraintHelpers on List<BucketLocationConstraint> {
 
   /// Returns the value of [BucketLocationConstraint] whose value matches [value].
   BucketLocationConstraint byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => BucketLocationConstraint._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/encoding_type.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/encoding_type.dart
@@ -33,6 +33,5 @@ extension EncodingTypeHelpers on List<EncodingType> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [EncodingType] whose value matches [value].
-  EncodingType byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EncodingType._sdkUnknown(value));
+  EncodingType byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/encoding_type.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/encoding_type.dart
@@ -8,7 +8,7 @@ class EncodingType extends _i1.SmithyEnum<EncodingType> {
   const EncodingType._(int index, String name, String value)
       : super(index, name, value);
 
-  const EncodingType.sdkUnknown(String value) : super.sdkUnknown(value);
+  const EncodingType._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const url = EncodingType._(0, 'url', 'url');
 
@@ -18,7 +18,7 @@ class EncodingType extends _i1.SmithyEnum<EncodingType> {
   static const List<_i1.SmithySerializer<EncodingType>> serializers = [
     _i1.SmithyEnumSerializer('EncodingType',
         values: values,
-        sdkUnknown: EncodingType.sdkUnknown,
+        sdkUnknown: EncodingType._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -34,5 +34,5 @@ extension EncodingTypeHelpers on List<EncodingType> {
 
   /// Returns the value of [EncodingType] whose value matches [value].
   EncodingType byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => EncodingType.sdkUnknown(value));
+      orElse: () => EncodingType._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/object_storage_class.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/object_storage_class.dart
@@ -61,6 +61,5 @@ extension ObjectStorageClassHelpers on List<ObjectStorageClass> {
 
   /// Returns the value of [ObjectStorageClass] whose value matches [value].
   ObjectStorageClass byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => ObjectStorageClass._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/object_storage_class.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/object_storage_class.dart
@@ -8,7 +8,7 @@ class ObjectStorageClass extends _i1.SmithyEnum<ObjectStorageClass> {
   const ObjectStorageClass._(int index, String name, String value)
       : super(index, name, value);
 
-  const ObjectStorageClass.sdkUnknown(String value) : super.sdkUnknown(value);
+  const ObjectStorageClass._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const deepArchive =
       ObjectStorageClass._(0, 'DEEP_ARCHIVE', 'DEEP_ARCHIVE');
@@ -45,7 +45,7 @@ class ObjectStorageClass extends _i1.SmithyEnum<ObjectStorageClass> {
   static const List<_i1.SmithySerializer<ObjectStorageClass>> serializers = [
     _i1.SmithyEnumSerializer('ObjectStorageClass',
         values: values,
-        sdkUnknown: ObjectStorageClass.sdkUnknown,
+        sdkUnknown: ObjectStorageClass._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -62,5 +62,5 @@ extension ObjectStorageClassHelpers on List<ObjectStorageClass> {
   /// Returns the value of [ObjectStorageClass] whose value matches [value].
   ObjectStorageClass byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => ObjectStorageClass.sdkUnknown(value));
+          orElse: () => ObjectStorageClass._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/request_payer.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/request_payer.dart
@@ -33,6 +33,5 @@ extension RequestPayerHelpers on List<RequestPayer> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RequestPayer] whose value matches [value].
-  RequestPayer byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RequestPayer._sdkUnknown(value));
+  RequestPayer byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/request_payer.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/request_payer.dart
@@ -8,7 +8,7 @@ class RequestPayer extends _i1.SmithyEnum<RequestPayer> {
   const RequestPayer._(int index, String name, String value)
       : super(index, name, value);
 
-  const RequestPayer.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RequestPayer._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const requester = RequestPayer._(0, 'requester', 'requester');
 
@@ -18,7 +18,7 @@ class RequestPayer extends _i1.SmithyEnum<RequestPayer> {
   static const List<_i1.SmithySerializer<RequestPayer>> serializers = [
     _i1.SmithyEnumSerializer('RequestPayer',
         values: values,
-        sdkUnknown: RequestPayer.sdkUnknown,
+        sdkUnknown: RequestPayer._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -34,5 +34,5 @@ extension RequestPayerHelpers on List<RequestPayer> {
 
   /// Returns the value of [RequestPayer] whose value matches [value].
   RequestPayer byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RequestPayer.sdkUnknown(value));
+      orElse: () => RequestPayer._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/retry_mode.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/retry_mode.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXml/lib/src/s3/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXml/lib/src/s3/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/retry_mode.dart
+++ b/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -43,5 +43,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/retry_mode.dart
+++ b/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/retry_mode.dart
@@ -42,6 +42,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [
           _i1.ShapeId(namespace: 'aws.protocols', shape: 'restXml')
         ])
@@ -44,5 +44,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/restXmlWithNamespace/lib/src/rest_xml_protocol_namespace/model/s3_addressing_style.dart
@@ -43,6 +43,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/function.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/function.dart
@@ -8,7 +8,7 @@ class TestFunction extends _i1.SmithyEnum<TestFunction> {
   const TestFunction._(int index, String name, String value)
       : super(index, name, value);
 
-  const TestFunction.sdkUnknown(String value) : super.sdkUnknown(value);
+  const TestFunction._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const index_ = TestFunction._(0, 'index', 'INDEX_');
 
@@ -18,7 +18,7 @@ class TestFunction extends _i1.SmithyEnum<TestFunction> {
   static const List<_i1.SmithySerializer<TestFunction>> serializers = [
     _i1.SmithyEnumSerializer('Function',
         values: values,
-        sdkUnknown: TestFunction.sdkUnknown,
+        sdkUnknown: TestFunction._sdkUnknown,
         supportedProtocols: [])
   ];
 }
@@ -32,5 +32,5 @@ extension TestFunctionHelpers on List<TestFunction> {
 
   /// Returns the value of [TestFunction] whose value matches [value].
   TestFunction byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => TestFunction.sdkUnknown(value));
+      orElse: () => TestFunction._sdkUnknown(value));
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/function.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/function.dart
@@ -31,6 +31,5 @@ extension TestFunctionHelpers on List<TestFunction> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [TestFunction] whose value matches [value].
-  TestFunction byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => TestFunction._sdkUnknown(value));
+  TestFunction byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/my_enum.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/my_enum.dart
@@ -8,7 +8,7 @@ class MyEnum extends _i1.SmithyEnum<MyEnum> {
   const MyEnum._(int index, String name, String value)
       : super(index, name, value);
 
-  const MyEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  const MyEnum._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const variant1 = MyEnum._(0, 'Variant1', 'rawValue1');
 
@@ -19,7 +19,7 @@ class MyEnum extends _i1.SmithyEnum<MyEnum> {
 
   static const List<_i1.SmithySerializer<MyEnum>> serializers = [
     _i1.SmithyEnumSerializer('MyEnum',
-        values: values, sdkUnknown: MyEnum.sdkUnknown, supportedProtocols: [])
+        values: values, sdkUnknown: MyEnum._sdkUnknown, supportedProtocols: [])
   ];
 }
 
@@ -32,5 +32,5 @@ extension MyEnumHelpers on List<MyEnum> {
 
   /// Returns the value of [MyEnum] whose value matches [value].
   MyEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => MyEnum.sdkUnknown(value));
+      orElse: () => MyEnum._sdkUnknown(value));
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/my_enum.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/my_enum.dart
@@ -31,6 +31,5 @@ extension MyEnumHelpers on List<MyEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [MyEnum] whose value matches [value].
-  MyEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => MyEnum._sdkUnknown(value));
+  MyEnum byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/retry_mode.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/retry_mode.dart
@@ -40,6 +40,5 @@ extension RetryModeHelpers on List<RetryMode> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [RetryMode] whose value matches [value].
-  RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode._sdkUnknown(value));
+  RetryMode byValue(String value) => firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/retry_mode.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/retry_mode.dart
@@ -9,7 +9,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   const RetryMode._(int index, String name, String value)
       : super(index, name, value);
 
-  const RetryMode.sdkUnknown(String value) : super.sdkUnknown(value);
+  const RetryMode._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const adaptive = RetryMode._(0, 'ADAPTIVE', 'adaptive');
 
@@ -27,7 +27,7 @@ class RetryMode extends _i1.SmithyEnum<RetryMode> {
   static const List<_i1.SmithySerializer<RetryMode>> serializers = [
     _i1.SmithyEnumSerializer('RetryMode',
         values: values,
-        sdkUnknown: RetryMode.sdkUnknown,
+        sdkUnknown: RetryMode._sdkUnknown,
         supportedProtocols: [])
   ];
 }
@@ -41,5 +41,5 @@ extension RetryModeHelpers on List<RetryMode> {
 
   /// Returns the value of [RetryMode] whose value matches [value].
   RetryMode byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => RetryMode.sdkUnknown(value));
+      orElse: () => RetryMode._sdkUnknown(value));
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/s3_addressing_style.dart
@@ -41,6 +41,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
 
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
-      firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle._sdkUnknown(value));
+      firstWhere((el) => el.value == value);
 }

--- a/packages/goldens/lib/structure_generator/lib/src/test/model/s3_addressing_style.dart
+++ b/packages/goldens/lib/structure_generator/lib/src/test/model/s3_addressing_style.dart
@@ -9,7 +9,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   const S3AddressingStyle._(int index, String name, String value)
       : super(index, name, value);
 
-  const S3AddressingStyle.sdkUnknown(String value) : super.sdkUnknown(value);
+  const S3AddressingStyle._sdkUnknown(String value) : super.sdkUnknown(value);
 
   static const auto = S3AddressingStyle._(0, 'AUTO', 'auto');
 
@@ -27,7 +27,7 @@ class S3AddressingStyle extends _i1.SmithyEnum<S3AddressingStyle> {
   static const List<_i1.SmithySerializer<S3AddressingStyle>> serializers = [
     _i1.SmithyEnumSerializer('S3AddressingStyle',
         values: values,
-        sdkUnknown: S3AddressingStyle.sdkUnknown,
+        sdkUnknown: S3AddressingStyle._sdkUnknown,
         supportedProtocols: [])
   ];
 }
@@ -42,5 +42,5 @@ extension S3AddressingStyleHelpers on List<S3AddressingStyle> {
   /// Returns the value of [S3AddressingStyle] whose value matches [value].
   S3AddressingStyle byValue(String value) =>
       firstWhere((el) => el.value == value,
-          orElse: () => S3AddressingStyle.sdkUnknown(value));
+          orElse: () => S3AddressingStyle._sdkUnknown(value));
 }

--- a/packages/smithy/lib/src/types/enum.dart
+++ b/packages/smithy/lib/src/types/enum.dart
@@ -40,8 +40,7 @@ import 'package:smithy/smithy.dart';
 ///   }
 /// }
 /// ```
-abstract class SmithyEnum<T extends SmithyEnum<T>>
-    with AWSEquatable<SmithyEnum<T>>, AWSSerializable {
+abstract class SmithyEnum<T extends SmithyEnum<T>> with AWSSerializable {
   const SmithyEnum(this.index, this.name, this.value);
   const SmithyEnum.sdkUnknown(this.value)
       : index = -1,
@@ -50,9 +49,6 @@ abstract class SmithyEnum<T extends SmithyEnum<T>>
   final int index;
   final String name;
   final String value;
-
-  @override
-  List<Object> get props => [T, index, name, value];
 
   @override
   String toJson() => value;

--- a/packages/smithy/test/enum_test.dart
+++ b/packages/smithy/test/enum_test.dart
@@ -1,0 +1,70 @@
+import 'package:smithy/smithy.dart';
+import 'package:test/test.dart';
+
+class _MyEnum extends SmithyEnum<_MyEnum> {
+  const _MyEnum._(int index, String name, String value)
+      : super(index, name, value);
+
+  const _MyEnum._sdkUnknown(String value) : super.sdkUnknown(value);
+
+  static const bar = _MyEnum._(0, 'BAR', 'Bar');
+
+  static const baz = _MyEnum._(1, 'BAZ', 'Baz');
+
+  static const foo = _MyEnum._(2, 'FOO', 'Foo');
+
+  /// All values of [_MyEnum].
+  static const values = <_MyEnum>[
+    _MyEnum.bar,
+    _MyEnum.baz,
+    _MyEnum.foo,
+  ];
+}
+
+extension _MyEnumHelpers on List<_MyEnum> {
+  /// Returns the value of [_MyEnum] whose name matches [name].
+  ///
+  /// Throws a `StateError` if no matching value is found.
+  _MyEnum byName(String name) =>
+      firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
+
+  /// Returns the value of [_MyEnum] whose value matches [value].
+  _MyEnum byValue(String value) => firstWhere((el) => el.value == value,
+      orElse: () => _MyEnum._sdkUnknown(value));
+}
+
+void main() {
+  group('SmithyEnum', () {
+    test('can switch', () {
+      _MyEnum getEnum() => _MyEnum.bar;
+      switch (getEnum()) {
+        case _MyEnum.bar:
+          break;
+        default:
+          fail('Did not switch correctly');
+      }
+    });
+
+    test('byName', () {
+      expect(
+        _MyEnum.values.byName('foo'),
+        equals(_MyEnum.foo),
+      );
+    });
+
+    test('byValue', () {
+      expect(
+        _MyEnum.values.byValue('Foo'),
+        equals(_MyEnum.foo),
+      );
+    });
+
+    test('byValue (unknown)', () {
+      final unknown = _MyEnum.values.byValue('UNKNOWN');
+      expect(
+        unknown.value,
+        equals('UNKNOWN'),
+      );
+    });
+  });
+}

--- a/packages/smithy/test/enum_test.dart
+++ b/packages/smithy/test/enum_test.dart
@@ -19,6 +19,16 @@ class _MyEnum extends SmithyEnum<_MyEnum> {
     _MyEnum.baz,
     _MyEnum.foo,
   ];
+
+  // ignore: unused_field
+  static const List<SmithySerializer<_MyEnum>> serializers = [
+    SmithyEnumSerializer(
+      '_MyEnum',
+      values: values,
+      sdkUnknown: _MyEnum._sdkUnknown,
+      supportedProtocols: [],
+    )
+  ];
 }
 
 extension _MyEnumHelpers on List<_MyEnum> {
@@ -29,8 +39,7 @@ extension _MyEnumHelpers on List<_MyEnum> {
       firstWhere((el) => el.name.toLowerCase() == name.toLowerCase());
 
   /// Returns the value of [_MyEnum] whose value matches [value].
-  _MyEnum byValue(String value) => firstWhere((el) => el.value == value,
-      orElse: () => _MyEnum._sdkUnknown(value));
+  _MyEnum byValue(String value) => firstWhere((el) => el.value == value);
 }
 
 void main() {
@@ -60,10 +69,9 @@ void main() {
     });
 
     test('byValue (unknown)', () {
-      final unknown = _MyEnum.values.byValue('UNKNOWN');
       expect(
-        unknown.value,
-        equals('UNKNOWN'),
+        () => _MyEnum.values.byValue('UNKNOWN'),
+        throwsStateError,
       );
     });
   });

--- a/packages/smithy_codegen/lib/src/generator/enum_generator.dart
+++ b/packages/smithy_codegen/lib/src/generator/enum_generator.dart
@@ -92,12 +92,12 @@ class EnumGenerator extends LibraryGenerator<StringShape> {
   /// enumerated ones.
   ///
   /// ```dart
-  /// const MyEnum.sdkUnknown(String value) : super.sdkUnknown(value);
+  /// const MyEnum._sdkUnknown(String value) : super.sdkUnknown(value);
   /// ```
   Constructor get _sdkUnknownConstructor => Constructor(
         (c) => c
           ..constant = true
-          ..name = 'sdkUnknown'
+          ..name = '_sdkUnknown'
           ..requiredParameters.add(Parameter((p) => p
             ..name = 'value'
             ..type = DartTypes.core.string))
@@ -150,7 +150,7 @@ class EnumGenerator extends LibraryGenerator<StringShape> {
         literalString(shape.shapeId.shape),
       ], {
         'values': refer('values'),
-        'sdkUnknown': symbol.property('sdkUnknown'),
+        'sdkUnknown': symbol.property('_sdkUnknown'),
         'supportedProtocols': literalConstList([
           for (final protocol in context.serviceProtocols)
             if (!protocol.isSynthetic) protocol.shapeId.constructed,
@@ -217,7 +217,7 @@ class EnumGenerator extends LibraryGenerator<StringShape> {
               (c) => c
                 ..lambda = true
                 ..body = symbol
-                    .newInstanceNamed('sdkUnknown', [refer('value')]).code,
+                    .newInstanceNamed('_sdkUnknown', [refer('value')]).code,
             ).closure,
           }).code,
       ),

--- a/packages/smithy_codegen/lib/src/generator/enum_generator.dart
+++ b/packages/smithy_codegen/lib/src/generator/enum_generator.dart
@@ -212,14 +212,7 @@ class EnumGenerator extends LibraryGenerator<StringShape> {
                 ..body =
                     refer('el').property('value').equalTo(refer('value')).code,
             ).closure,
-          ], {
-            'orElse': Method(
-              (c) => c
-                ..lambda = true
-                ..body = symbol
-                    .newInstanceNamed('_sdkUnknown', [refer('value')]).code,
-            ).closure,
-          }).code,
+          ]).code,
       ),
     ]));
 }


### PR DESCRIPTION
Minor corrections to enum generation to support Dart analysis as enum:

1. Do not override `==`/`hashCode` so they can be used in switch statements.
2. Make `sdkUnknown` private so that Dart provides helpers for switch statements.

Before:
<img width="358" alt="Screen Shot 2022-02-07 at 7 58 55 AM" src="https://user-images.githubusercontent.com/24740863/152813602-69993492-823e-428d-bfdb-7a34fd7846f1.png">

After:
<img width="355" alt="Screen Shot 2022-02-07 at 7 59 02 AM" src="https://user-images.githubusercontent.com/24740863/152813628-c82302e3-5439-4f29-a124-d4e22378c208.png">

